### PR TITLE
Improve CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.8)
 project(indica VERSION 1.0.0 LANGUAGES CXX)
 option(INDICA_BUILD_TESTS OFF)
 
+include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
+
+find_package(Threads REQUIRED)
 
 add_library(indica INTERFACE)
 add_library(indica::indica ALIAS indica)
@@ -11,10 +14,20 @@ target_compile_features(indica INTERFACE cxx_std_11)
 target_include_directories(indica INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
+target_link_libraries(indica INTERFACE Threads::Threads)
 
-install(TARGETS indica EXPORT indicaConfig)
-install(EXPORT indicaConfig
+configure_package_config_file(indicaConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/indicaConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/indica)
+
+install(TARGETS indica EXPORT indicaTargets)
+install(EXPORT indicaTargets
+        FILE indicaTargets.cmake
         NAMESPACE indica::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/indica)
-install(FILES ${CMAKE_CURRENT_LIST_DIR}/include/indica.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/indica)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indicaConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/indica)
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/indicators
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        USE_SOURCE_PERMISSIONS
+        PATTERN "*.hpp")

--- a/indicaConfig.cmake.in
+++ b/indicaConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
+if (NOT TARGET indica::indica)
+  include(${CMAKE_CURRENT_LIST_DIR}/indicaTargets.cmake)
+endif ()


### PR DESCRIPTION
Improve CMakeLists.txt
- Fix headers installation;
- Handle Threads dependency automatically;

    That way, the users of this library do not have to link against `pthread` themselves.
    Instead of:
    ```
    find_package(indica CONFIG REQUIRED)
    find_package(Threads REQUIRED)
    target_link_libraries(my_app PRIVATE indica::indica Threads::Threads)
    ```
    the users can do it like this now:
    ```
    find_package(indica CONFIG REQUIRED)
    target_link_libraries(my_app PRIVATE indica::indica)
    ```    
    