### PR TITLE
CMake support for Demo and Samples 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(indica VERSION 1.0.0 LANGUAGES CXX)
 option(INDICA_BUILD_TESTS OFF)
 option(SAMPLES "Build Samples" OFF)
+option(DEMO "Build Demo" OFF)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -17,6 +18,10 @@ target_include_directories(indica INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 target_link_libraries(indica INTERFACE Threads::Threads)
 
+
+if( DEMO )
+    add_subdirectory(demo)
+endif()
 
 if( SAMPLES )
     add_subdirectory(samples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(indica VERSION 1.0.0 LANGUAGES CXX)
 option(INDICA_BUILD_TESTS OFF)
+option(SAMPLES "Build Samples" OFF)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -15,6 +16,11 @@ target_include_directories(indica INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 target_link_libraries(indica INTERFACE Threads::Threads)
+
+
+if( SAMPLES )
+    add_subdirectory(samples)
+endif()
 
 configure_package_config_file(indicaConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/indicaConfig.cmake

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(demo demo.cpp)
+target_link_libraries(demo PRIVATE indica::indica)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+add_executable(block_progress_bar block_progress_bar.cpp)
+target_link_libraries(block_progress_bar PRIVATE indica::indica)
+
+add_executable(multi_threaded_bar multi_threaded_bar.cpp)
+target_link_libraries(multi_threaded_bar PRIVATE indica::indica)
+
+add_executable(progress_bar_set_progress progress_bar_set_progress.cpp)
+target_link_libraries(progress_bar_set_progress PRIVATE indica::indica)
+
+add_executable(progress_bar_tick progress_bar_tick.cpp)
+target_link_libraries(progress_bar_tick PRIVATE indica::indica)
+
+add_executable(progress_spinner progress_spinner.cpp)
+target_link_libraries(progress_spinner PRIVATE indica::indica)


### PR DESCRIPTION
Adds CMake support for building the demo and samples. Both are available via option and off by default.