### PR TITLE
Small improvement: using lock_guard instead of unique_lock

### DIFF
--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -43,32 +43,32 @@ namespace indicators {
 class BlockProgressBar {
 public:
   void set_foreground_color(Color color) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _foreground_color = color;
   }
 
   void set_bar_width(size_t bar_width) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _bar_width = bar_width;
   }
 
   void start_bar_with(const std::string &start) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _start = start;
   }
 
   void end_bar_with(const std::string &end) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _end = end;
   }
 
   void set_prefix_text(const std::string &text) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _prefix_text = text;
   }
 
   void set_postfix_text(const std::string &text) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _postfix_text = text;
     if (_postfix_text.length() > _max_postfix_text_length)
       _max_postfix_text_length = _postfix_text.length();
@@ -88,7 +88,7 @@ public:
 
   void set_progress(float value) {
     {
-      std::unique_lock<std::mutex> lock{_mutex};
+      std::lock_guard<std::mutex> lock{_mutex};
       _progress = value;
     }
     _save_start_time();
@@ -97,7 +97,7 @@ public:
 
   void tick() {
     {
-      std::unique_lock<std::mutex> lock{_mutex};
+      std::lock_guard<std::mutex> lock{_mutex};
       _progress += 1;
     }
     _save_start_time();
@@ -105,7 +105,7 @@ public:
   }
 
   size_t current() {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     return std::min(static_cast<size_t>(_progress), size_t(100));
   }
 
@@ -175,7 +175,7 @@ private:
       }
       return;
     }
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _start_time_point);
 

--- a/include/indicators/multi_progress.hpp
+++ b/include/indicators/multi_progress.hpp
@@ -77,7 +77,7 @@ private:
   }
 
   void _print_progress() {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     if (_started)
       for (size_t i = 0; i < count; ++i)
         std::cout << "\x1b[A";

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -42,47 +42,47 @@ namespace indicators {
 class ProgressBar {
 public:
   void set_foreground_color(Color color) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _foreground_color = color;
   }
 
   void set_bar_width(size_t bar_width) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _bar_width = bar_width;
   }
 
   void start_bar_with(const std::string &start) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _start = start;
   }
 
   void fill_bar_progress_with(const std::string &fill) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _fill = fill;
   }
 
   void lead_bar_progress_with(const std::string &lead) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _lead = lead;
   }
 
   void fill_bar_remainder_with(const std::string &remainder) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _remainder = remainder;
   }
 
   void end_bar_with(const std::string &end) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _end = end;
   }
 
   void set_prefix_text(const std::string &text) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _prefix_text = text;
   }
 
   void set_postfix_text(const std::string &text) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _postfix_text = text;
     if (_postfix_text.length() > _max_postfix_text_length)
       _max_postfix_text_length = _postfix_text.length();
@@ -102,7 +102,7 @@ public:
 
   void set_progress(float value) {
     {
-      std::unique_lock<std::mutex> lock{_mutex};
+      std::lock_guard<std::mutex> lock{_mutex};
       _progress = value;
     }
     _save_start_time();
@@ -111,7 +111,7 @@ public:
 
   void tick() {
     {
-      std::unique_lock<std::mutex> lock{_mutex};
+      std::lock_guard<std::mutex> lock{_mutex};
       _progress += 1;
     }
     _save_start_time();
@@ -119,7 +119,7 @@ public:
   }
 
   size_t current() {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     return std::min(static_cast<size_t>(_progress), size_t(100));
   }
 
@@ -189,7 +189,7 @@ private:
       }
       return;
     }
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _start_time_point);
 

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -43,17 +43,17 @@ namespace indicators {
 class ProgressSpinner {
 public:
   void set_foreground_color(Color color) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _foreground_color = color;
   }
 
   void set_prefix_text(const std::string &text) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _prefix_text = text;
   }
 
   void set_postfix_text(const std::string &text) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _postfix_text = text;
     if (_postfix_text.length() > _max_postfix_text_length)
       _max_postfix_text_length = _postfix_text.length();
@@ -77,7 +77,7 @@ public:
 
   void set_progress(float value) {
     {
-      std::unique_lock<std::mutex> lock{_mutex};
+      std::lock_guard<std::mutex> lock{_mutex};
       _progress = value;
     }
     _save_start_time();
@@ -86,7 +86,7 @@ public:
 
   void tick() {
     {
-      std::unique_lock<std::mutex> lock{_mutex};
+      std::lock_guard<std::mutex> lock{_mutex};
       _progress += 1;
     }
     _save_start_time();
@@ -94,7 +94,7 @@ public:
   }
 
   size_t current() {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     return std::min(static_cast<size_t>(_progress), size_t(100));
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   void set_spinner_states(const std::vector<std::string> &states) {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     _states = states;
   }
 
@@ -157,7 +157,7 @@ private:
   }
 
   void _print_progress() {
-    std::unique_lock<std::mutex> lock{_mutex};
+    std::lock_guard<std::mutex> lock{_mutex};
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _start_time_point);
 


### PR DESCRIPTION
Hello,

I want to propose small improvement: using `std::lock_guard` instead of `std::unique_lock`. The size of `std::unique_lock` is 16 bytes, the size of `std::lock_guard` is 8 bytes. We can change using `std::unique_lock` without any problems because locks are trivial. 