### PR TITLE
Remove code duplication: extract set_stream_color function

### DIFF
--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -25,6 +25,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 #pragma once
+
+#include <indicators/details/stream_helper.hpp>
+
 #define NOMINMAX
 #include <algorithm>
 #include <atomic>
@@ -180,32 +183,7 @@ private:
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _start_time_point);
 
     std::cout << termcolor::bold;
-    switch (_foreground_color) {
-    case Color::GREY:
-      std::cout << termcolor::grey;
-      break;
-    case Color::RED:
-      std::cout << termcolor::red;
-      break;
-    case Color::GREEN:
-      std::cout << termcolor::green;
-      break;
-    case Color::YELLOW:
-      std::cout << termcolor::yellow;
-      break;
-    case Color::BLUE:
-      std::cout << termcolor::blue;
-      break;
-    case Color::MAGENTA:
-      std::cout << termcolor::magenta;
-      break;
-    case Color::CYAN:
-      std::cout << termcolor::cyan;
-      break;
-    case Color::WHITE:
-      std::cout << termcolor::white;
-      break;
-    }
+    details::set_stream_color(std::cout, _foreground_color);
     std::cout << _prefix_text;
     std::cout << _start;
 

--- a/include/indicators/details/stream_helper.hpp
+++ b/include/indicators/details/stream_helper.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <indicators/color.hpp>
+
+#include <ostream>
+#include <cassert>
+
+namespace indicators {
+namespace details {
+
+inline void set_stream_color(std::ostream& stream, Color color) {
+    switch (color) {
+    case Color::GREY:
+      stream << termcolor::grey;
+      break;
+    case Color::RED:
+      stream << termcolor::red;
+      break;
+    case Color::GREEN:
+      stream << termcolor::green;
+      break;
+    case Color::YELLOW:
+      stream << termcolor::yellow;
+      break;
+    case Color::BLUE:
+      stream << termcolor::blue;
+      break;
+    case Color::MAGENTA:
+      stream << termcolor::magenta;
+      break;
+    case Color::CYAN:
+      stream << termcolor::cyan;
+      break;
+    case Color::WHITE:
+      stream << termcolor::white;
+      break;
+    default:
+      assert(false);
+    }
+}
+
+}
+}

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -25,6 +25,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 #pragma once
+
+#include <indicators/details/stream_helper.hpp>
+
 #define NOMINMAX
 #include <algorithm>
 #include <atomic>
@@ -194,32 +197,7 @@ private:
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _start_time_point);
 
     std::cout << termcolor::bold;
-    switch (_foreground_color) {
-    case Color::GREY:
-      std::cout << termcolor::grey;
-      break;
-    case Color::RED:
-      std::cout << termcolor::red;
-      break;
-    case Color::GREEN:
-      std::cout << termcolor::green;
-      break;
-    case Color::YELLOW:
-      std::cout << termcolor::yellow;
-      break;
-    case Color::BLUE:
-      std::cout << termcolor::blue;
-      break;
-    case Color::MAGENTA:
-      std::cout << termcolor::magenta;
-      break;
-    case Color::CYAN:
-      std::cout << termcolor::cyan;
-      break;
-    case Color::WHITE:
-      std::cout << termcolor::white;
-      break;
-    }
+    details::set_stream_color(std::cout, _foreground_color);
     std::cout << _prefix_text;
     std::cout << _start;
     auto pos = static_cast<size_t>(_progress * static_cast<float>(_bar_width) / 100.0);

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -25,6 +25,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 #pragma once
+
+#include <indicators/details/stream_helper.hpp>
+
 #define NOMINMAX
 #include <algorithm>
 #include <atomic>
@@ -162,32 +165,7 @@ private:
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _start_time_point);
 
     std::cout << termcolor::bold;
-    switch (_foreground_color) {
-    case Color::GREY:
-      std::cout << termcolor::grey;
-      break;
-    case Color::RED:
-      std::cout << termcolor::red;
-      break;
-    case Color::GREEN:
-      std::cout << termcolor::green;
-      break;
-    case Color::YELLOW:
-      std::cout << termcolor::yellow;
-      break;
-    case Color::BLUE:
-      std::cout << termcolor::blue;
-      break;
-    case Color::MAGENTA:
-      std::cout << termcolor::magenta;
-      break;
-    case Color::CYAN:
-      std::cout << termcolor::cyan;
-      break;
-    case Color::WHITE:
-      std::cout << termcolor::white;
-      break;
-    }
+    details::set_stream_color(std::cout, _foreground_color);
     std::cout << _prefix_text;
     if (_show_spinner)
       std::cout << _states[_index % _states.size()];


### PR DESCRIPTION
Hello again,

I have noticed code duplication in setting `std::cout` color and decided to make this change.