### PR TITLE
Remove code duplication: move _print_duration to details + small fixes

### DIFF
--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -142,28 +142,6 @@ private:
   template <typename Indicator, size_t count> friend class MultiProgress;
   std::atomic<bool> _multi_progress_mode{false};
 
-  std::ostream &_print_duration(std::ostream &os, std::chrono::nanoseconds ns) {
-    using namespace std;
-    using namespace std::chrono;
-    typedef duration<int, ratio<86400>> days;
-    char fill = os.fill();
-    os.fill('0');
-    auto d = duration_cast<days>(ns);
-    ns -= d;
-    auto h = duration_cast<hours>(ns);
-    ns -= h;
-    auto m = duration_cast<minutes>(ns);
-    ns -= m;
-    auto s = duration_cast<seconds>(ns);
-    if (d.count() > 0)
-      os << setw(2) << d.count() << "d:";
-    if (h.count() > 0)
-      os << setw(2) << h.count() << "h:";
-    os << setw(2) << m.count() << "m:" << setw(2) << s.count() << 's';
-    os.fill(fill);
-    return os;
-  };
-
   void _save_start_time() {
     if ((_show_elapsed_time || _show_remaining_time) && !_saved_start_time) {
       _start_time_point = std::chrono::high_resolution_clock::now();
@@ -208,7 +186,7 @@ private:
 
     if (_show_elapsed_time) {
       std::cout << " [";
-      _print_duration(std::cout, elapsed);
+      details::print_duration(std::cout, elapsed);
     }
 
     if (_show_remaining_time) {
@@ -219,7 +197,7 @@ private:
       auto eta = std::chrono::nanoseconds(
           _progress > 0 ? static_cast<long long>(elapsed.count() * 100 / _progress) : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
-      _print_duration(std::cout, remaining);
+      details::print_duration(std::cout, remaining);
       std::cout << "]";
     } else {
       if (_show_elapsed_time)

--- a/include/indicators/details/stream_helper.hpp
+++ b/include/indicators/details/stream_helper.hpp
@@ -1,43 +1,69 @@
 #pragma once
 
 #include <indicators/color.hpp>
+#include <indicators/termcolor.hpp>
 
+#include <chrono>
+#include <iomanip>
 #include <ostream>
+
 #include <cassert>
 
 namespace indicators {
 namespace details {
 
-inline void set_stream_color(std::ostream& stream, Color color) {
+inline void set_stream_color(std::ostream &os, Color color) {
     switch (color) {
-    case Color::GREY:
-      stream << termcolor::grey;
-      break;
-    case Color::RED:
-      stream << termcolor::red;
-      break;
-    case Color::GREEN:
-      stream << termcolor::green;
-      break;
-    case Color::YELLOW:
-      stream << termcolor::yellow;
-      break;
-    case Color::BLUE:
-      stream << termcolor::blue;
-      break;
-    case Color::MAGENTA:
-      stream << termcolor::magenta;
-      break;
-    case Color::CYAN:
-      stream << termcolor::cyan;
-      break;
-    case Color::WHITE:
-      stream << termcolor::white;
-      break;
-    default:
-      assert(false);
+        case Color::GREY:
+            os << termcolor::grey;
+            break;
+        case Color::RED:
+            os << termcolor::red;
+            break;
+        case Color::GREEN:
+            os << termcolor::green;
+            break;
+        case Color::YELLOW:
+            os << termcolor::yellow;
+            break;
+        case Color::BLUE:
+            os << termcolor::blue;
+            break;
+        case Color::MAGENTA:
+            os << termcolor::magenta;
+            break;
+        case Color::CYAN:
+            os << termcolor::cyan;
+            break;
+        case Color::WHITE:
+            os << termcolor::white;
+            break;
+        default:
+            assert(false);
     }
 }
+
+std::ostream &print_duration(std::ostream &os, std::chrono::nanoseconds ns) {
+    using namespace std;
+    using namespace std::chrono;
+    using days = duration<int, ratio<86400>>;
+    char fill = os.fill();
+    os.fill('0');
+    auto d = duration_cast<days>(ns);
+    ns -= d;
+    auto h = duration_cast<hours>(ns);
+    ns -= h;
+    auto m = duration_cast<minutes>(ns);
+    ns -= m;
+    auto s = duration_cast<seconds>(ns);
+    if (d.count() > 0)
+        os << setw(2) << d.count() << "d:";
+    if (h.count() > 0)
+        os << setw(2) << h.count() << "h:";
+    os << setw(2) << m.count() << "m:" << setw(2) << s.count() << 's';
+    os.fill(fill);
+    return os;
+};
 
 }
 }

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -156,28 +156,6 @@ private:
   template <typename Indicator, size_t count> friend class MultiProgress;
   std::atomic<bool> _multi_progress_mode{false};
 
-  std::ostream &_print_duration(std::ostream &os, std::chrono::nanoseconds ns) {
-    using namespace std;
-    using namespace std::chrono;
-    typedef duration<int, ratio<86400>> days;
-    char fill = os.fill();
-    os.fill('0');
-    auto d = duration_cast<days>(ns);
-    ns -= d;
-    auto h = duration_cast<hours>(ns);
-    ns -= h;
-    auto m = duration_cast<minutes>(ns);
-    ns -= m;
-    auto s = duration_cast<seconds>(ns);
-    if (d.count() > 0)
-      os << setw(2) << d.count() << "d:";
-    if (h.count() > 0)
-      os << setw(2) << h.count() << "h:";
-    os << setw(2) << m.count() << "m:" << setw(2) << s.count() << 's';
-    os.fill(fill);
-    return os;
-  };
-
   void _save_start_time() {
     if ((_show_elapsed_time || _show_remaining_time) && !_saved_start_time) {
       _start_time_point = std::chrono::high_resolution_clock::now();
@@ -216,7 +194,7 @@ private:
 
     if (_show_elapsed_time) {
       std::cout << " [";
-      _print_duration(std::cout, elapsed);
+      details::print_duration(std::cout, elapsed);
     }
 
     if (_show_remaining_time) {
@@ -227,7 +205,7 @@ private:
       auto eta = std::chrono::nanoseconds(
           _progress > 0 ? static_cast<long long>(elapsed.count() * 100 / _progress) : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
-      _print_duration(std::cout, remaining);
+      details::print_duration(std::cout, remaining);
       std::cout << "]";
     } else {
       if (_show_elapsed_time)

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -130,28 +130,6 @@ private:
   std::mutex _mutex;
   Color _foreground_color;
 
-  std::ostream &_print_duration(std::ostream &os, std::chrono::nanoseconds ns) {
-    using namespace std;
-    using namespace std::chrono;
-    typedef duration<int, ratio<86400>> days;
-    char fill = os.fill();
-    os.fill('0');
-    auto d = duration_cast<days>(ns);
-    ns -= d;
-    auto h = duration_cast<hours>(ns);
-    ns -= h;
-    auto m = duration_cast<minutes>(ns);
-    ns -= m;
-    auto s = duration_cast<seconds>(ns);
-    if (d.count() > 0)
-      os << setw(2) << d.count() << "d:";
-    if (h.count() > 0)
-      os << setw(2) << h.count() << "h:";
-    os << setw(2) << m.count() << "m:" << setw(2) << s.count() << 's';
-    os.fill(fill);
-    return os;
-  };
-
   void _save_start_time() {
     if ((_show_elapsed_time || _show_remaining_time) && !_saved_start_time) {
       _start_time_point = std::chrono::high_resolution_clock::now();
@@ -175,7 +153,7 @@ private:
 
     if (_show_elapsed_time) {
       std::cout << " [";
-      _print_duration(std::cout, elapsed);
+      details::print_duration(std::cout, elapsed);
     }
 
     if (_show_remaining_time) {
@@ -186,7 +164,7 @@ private:
       auto eta = std::chrono::nanoseconds(
           _progress > 0 ? static_cast<long long>(elapsed.count() * 100 / _progress) : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
-      _print_duration(std::cout, remaining);
+      details::print_duration(std::cout, remaining);
       std::cout << "]";
     } else {
       if (_show_elapsed_time)


### PR DESCRIPTION
I have found one more function that is used in several placed and can be move to the common place. Also I have added `#include <indicators/termcolor.hpp>` include that was missed in the previous PR.