### PR TITLE
Extract progress scale writing logic into separate classes

### DIFF
--- a/include/indicators/details/stream_helper.hpp
+++ b/include/indicators/details/stream_helper.hpp
@@ -92,6 +92,7 @@ public:
         os << lead_text;
         for (size_t i = 0; i < (bar_width - whole_width - 1); ++i)
         os << " ";
+        return os;
     }
 private:
     std::ostream& os;
@@ -117,12 +118,13 @@ public:
         auto pos = static_cast<size_t>(progress * static_cast<float>(bar_width) / 100.0);
         for (size_t i = 0; i < bar_width; ++i) {
         if (i < pos)
-            std::cout << fill;
+            os << fill;
         else if (i == pos)
-            std::cout << lead;
+            os << lead;
         else
-            std::cout << remainder;
+            os << remainder;
         }
+        return os;
     }
 
 private:

--- a/include/indicators/details/stream_helper.hpp
+++ b/include/indicators/details/stream_helper.hpp
@@ -3,11 +3,15 @@
 #include <indicators/color.hpp>
 #include <indicators/termcolor.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <ostream>
+#include <string>
+#include <vector>
 
 #include <cassert>
+#include <cmath>
 
 namespace indicators {
 namespace details {
@@ -43,7 +47,7 @@ inline void set_stream_color(std::ostream &os, Color color) {
     }
 }
 
-std::ostream &print_duration(std::ostream &os, std::chrono::nanoseconds ns) {
+inline std::ostream &write_duration(std::ostream &os, std::chrono::nanoseconds ns) {
     using namespace std;
     using namespace std::chrono;
     using days = duration<int, ratio<86400>>;
@@ -63,6 +67,70 @@ std::ostream &print_duration(std::ostream &os, std::chrono::nanoseconds ns) {
     os << setw(2) << m.count() << "m:" << setw(2) << s.count() << 's';
     os.fill(fill);
     return os;
+};
+
+class BlockProgressScaleWriter
+{
+public:
+    BlockProgressScaleWriter(std::ostream& os, size_t bar_width)
+        : os(os)
+        , bar_width(bar_width)
+    {}
+
+    std::ostream &write(float progress) {
+        std::string fill_text{"█"};
+        std::vector<std::string> lead_characters{" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉"};
+        auto value = std::min(1.0f, std::max(0.0f, progress / 100.0f));
+        auto whole_width = std::floor(value * bar_width);
+        auto remainder_width = fmod((value * bar_width), 1.0f);
+        auto part_width = std::floor(remainder_width * lead_characters.size());
+        std::string lead_text = lead_characters[size_t(part_width)];
+        if ((bar_width - whole_width - 1) < 0)
+        lead_text = "";
+        for (size_t i = 0; i < whole_width; ++i)
+        os << fill_text;
+        os << lead_text;
+        for (size_t i = 0; i < (bar_width - whole_width - 1); ++i)
+        os << " ";
+    }
+private:
+    std::ostream& os;
+    size_t bar_width = 0;
+};
+
+class ProgressScaleWriter
+{
+public:
+    ProgressScaleWriter(std::ostream& os,
+                        size_t bar_width,
+                        std::string fill,
+                        std::string lead,
+                        std::string remainder)
+        : os(os)
+        , bar_width(bar_width)
+        , fill(fill)
+        , lead(lead)
+        , remainder(remainder)
+        {}
+
+    std::ostream &write(float progress) {
+        auto pos = static_cast<size_t>(progress * static_cast<float>(bar_width) / 100.0);
+        for (size_t i = 0; i < bar_width; ++i) {
+        if (i < pos)
+            std::cout << fill;
+        else if (i == pos)
+            std::cout << lead;
+        else
+            std::cout << remainder;
+        }
+    }
+
+private:
+    std::ostream& os;
+    size_t bar_width = 0;
+    std::string fill;
+    std::string lead;
+    std::string remainder;
 };
 
 }

--- a/include/indicators/details/stream_helper.hpp
+++ b/include/indicators/details/stream_helper.hpp
@@ -103,9 +103,9 @@ class ProgressScaleWriter
 public:
     ProgressScaleWriter(std::ostream& os,
                         size_t bar_width,
-                        std::string fill,
-                        std::string lead,
-                        std::string remainder)
+                        const std::string& fill,
+                        const std::string& lead,
+                        const std::string& remainder)
         : os(os)
         , bar_width(bar_width)
         , fill(fill)

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -177,24 +177,21 @@ private:
     std::cout << termcolor::bold;
     details::set_stream_color(std::cout, _foreground_color);
     std::cout << _prefix_text;
+
     std::cout << _start;
-    auto pos = static_cast<size_t>(_progress * static_cast<float>(_bar_width) / 100.0);
-    for (size_t i = 0; i < _bar_width; ++i) {
-      if (i < pos)
-        std::cout << _fill;
-      else if (i == pos)
-        std::cout << _lead;
-      else
-        std::cout << _remainder;
-    }
+
+    details::ProgressScaleWriter writer{std::cout, _bar_width, _fill, _lead, _remainder};
+    writer.write(_progress);
+
     std::cout << _end;
+
     if (_show_percentage) {
       std::cout << " " << std::min(static_cast<size_t>(_progress), size_t(100)) << "%";
     }
 
     if (_show_elapsed_time) {
       std::cout << " [";
-      details::print_duration(std::cout, elapsed);
+      details::write_duration(std::cout, elapsed);
     }
 
     if (_show_remaining_time) {
@@ -205,7 +202,7 @@ private:
       auto eta = std::chrono::nanoseconds(
           _progress > 0 ? static_cast<long long>(elapsed.count() * 100 / _progress) : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
-      details::print_duration(std::cout, remaining);
+      details::write_duration(std::cout, remaining);
       std::cout << "]";
     } else {
       if (_show_elapsed_time)

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -153,7 +153,7 @@ private:
 
     if (_show_elapsed_time) {
       std::cout << " [";
-      details::print_duration(std::cout, elapsed);
+      details::write_duration(std::cout, elapsed);
     }
 
     if (_show_remaining_time) {
@@ -164,7 +164,7 @@ private:
       auto eta = std::chrono::nanoseconds(
           _progress > 0 ? static_cast<long long>(elapsed.count() * 100 / _progress) : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
-      details::print_duration(std::cout, remaining);
+      details::write_duration(std::cout, remaining);
       std::cout << "]";
     } else {
       if (_show_elapsed_time)


### PR DESCRIPTION
Hello,

I have decided to refactor code and extract progress scale writing logic into separate classes. What do you think about it?
From my point of view, It would be better, for instance, to use `BlockProgressScaleWriter` as a field in `BlockProgressBar` class, but `bar_width` value can be changed during execution and I have instantiate `BlockProgressBar` each time when `_print_progress` is called.