### PR TITLE
Fix indicators.pc.in if explicit includedir is set

### DIFF
--- a/indicators.pc.in
+++ b/indicators.pc.in
@@ -1,5 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: indicators
 Description: Activity Indicators for Modern C++


### PR DESCRIPTION
This fixes cases where both -DCMAKE_INSTALL_PREFIX and -DCMAKE_INSTALL_INCLUDEDIR is set.