### PR TITLE
remove bold output and default color to unspecified

### DIFF
--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -55,7 +55,7 @@ public:
                                     void *>::type = nullptr>
   explicit BlockProgressBar(Args &&... args)
       : settings_(details::get<details::ProgressBarOption::foreground_color>(
-                      option::ForegroundColor{Color::white}, std::forward<Args>(args)...),
+                      option::ForegroundColor{Color::unspecified}, std::forward<Args>(args)...),
                   details::get<details::ProgressBarOption::bar_width>(option::BarWidth{100},
                                                                       std::forward<Args>(args)...),
                   details::get<details::ProgressBarOption::start>(option::Start{"["},
@@ -188,8 +188,8 @@ private:
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_time_point_);
 
-    std::cout << termcolor::bold;
-    details::set_stream_color(std::cout, get_value<details::ProgressBarOption::foreground_color>());
+    if (get_value<details::ProgressBarOption::foreground_color>() != Color::unspecified)
+      details::set_stream_color(std::cout, get_value<details::ProgressBarOption::foreground_color>());
     std::cout << get_value<details::ProgressBarOption::prefix_text>();
     std::cout << get_value<details::ProgressBarOption::start>();
 

--- a/include/indicators/color.hpp
+++ b/include/indicators/color.hpp
@@ -28,5 +28,5 @@ SOFTWARE.
 #include <indicators/termcolor.hpp>
 
 namespace indicators {
-enum class Color { grey, red, green, yellow, blue, magenta, cyan, white };
+enum class Color { grey, red, green, yellow, blue, magenta, cyan, white, unspecified };
 }

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -87,7 +87,7 @@ public:
                   details::get<details::ProgressBarOption::saved_start_time>(
                       option::SavedStartTime{false}, std::forward<Args>(args)...),
                   details::get<details::ProgressBarOption::foreground_color>(
-                      option::ForegroundColor{Color::white}, std::forward<Args>(args)...)) {}
+                      option::ForegroundColor{Color::unspecified}, std::forward<Args>(args)...)) {}
 
   template <typename T, details::ProgressBarOption id>
   void set_option(details::Setting<T, id> &&setting) {
@@ -201,8 +201,8 @@ private:
     if (!get_value<details::ProgressBarOption::completed>())
       elapsed_ = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_time_point_);
 
-    std::cout << termcolor::bold;
-    details::set_stream_color(std::cout, get_value<details::ProgressBarOption::foreground_color>());
+    if (get_value<details::ProgressBarOption::foreground_color>() != Color::unspecified)
+      details::set_stream_color(std::cout, get_value<details::ProgressBarOption::foreground_color>());
     std::cout << get_value<details::ProgressBarOption::prefix_text>();
 
     std::cout << get_value<details::ProgressBarOption::start>();

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -58,7 +58,7 @@ public:
                                     void *>::type = nullptr>
   explicit ProgressSpinner(Args &&... args)
       : settings_(details::get<details::ProgressBarOption::foreground_color>(
-                      option::ForegroundColor{Color::white}, std::forward<Args>(args)...),
+                      option::ForegroundColor{Color::unspecified}, std::forward<Args>(args)...),
                   details::get<details::ProgressBarOption::prefix_text>(
                       option::PrefixText{}, std::forward<Args>(args)...),
                   details::get<details::ProgressBarOption::postfix_text>(
@@ -182,8 +182,8 @@ private:
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_time_point_);
 
-    std::cout << termcolor::bold;
-    details::set_stream_color(std::cout, get_value<details::ProgressBarOption::foreground_color>());
+    if (get_value<details::ProgressBarOption::foreground_color>() != Color::unspecified)
+      details::set_stream_color(std::cout, get_value<details::ProgressBarOption::foreground_color>());
     std::cout << get_value<details::ProgressBarOption::prefix_text>();
     if (get_value<details::ProgressBarOption::spinner_show>())
       std::cout << get_value<details::ProgressBarOption::spinner_states>()


### PR DESCRIPTION
Hi @p-ranav this is probably a bit controversial but I have modified the code so that a "unspecified" color is available (just the default color from the terminal) and made it the default. 
I also removed the default of making the font bold.

Let me know if you don't want me to make these two things the default. 

Maybe we can add a setting for `bold`, and `italic`?