### PR TITLE
Support versions of CMake going back to version 3.8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,17 @@ if(DEFINED PROJECT_NAME)
   set(INDICATORS_SUBPROJECT ON)
 endif()
 
-project(indicators VERSION 1.8.0 LANGUAGES CXX
-  HOMEPAGE_URL "https://github.com/p-ranav/indicators"
-  DESCRIPTION "Activity Indicators for Modern C++")
-  
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
+  project(indicators VERSION 1.8.0 LANGUAGES CXX
+    HOMEPAGE_URL "https://github.com/p-ranav/indicators"
+    DESCRIPTION "Activity Indicators for Modern C++")
+elseif(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
+  project(indicators VERSION 1.8.0 LANGUAGES CXX
+    DESCRIPTION "Activity Indicators for Modern C++")
+else()
+  project(indicators VERSION 1.8.0 LANGUAGES CXX)
+endif()
+
 if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     conan_basic_setup()


### PR DESCRIPTION
The `DESCRIPTION` parameter of the `project()` command was introduced in CMake version 3.9.

The `HOMEPAGE_URL` parameter was introduced in CMake version 3.11.