### PR TITLE
Add a MaxProgress option (default: 100).

### DIFF
--- a/include/indicators/setting.hpp
+++ b/include/indicators/setting.hpp
@@ -89,7 +89,8 @@ enum class ProgressBarOption {
   spinner_show,
   spinner_states,
   font_styles,
-  hide_bar_when_complete
+  hide_bar_when_complete,
+  max_progress
 };
 
 template <typename T, ProgressBarOption Id> struct Setting {
@@ -204,5 +205,6 @@ using HideBarWhenComplete =
     details::BooleanSetting<details::ProgressBarOption::hide_bar_when_complete>;
 using FontStyles =
     details::Setting<std::vector<FontStyle>, details::ProgressBarOption::font_styles>;
+using MaxProgress = details::IntegerSetting<details::ProgressBarOption::max_progress>;
 } // namespace option
 } // namespace indicators

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -25,3 +25,7 @@ target_link_libraries(multi_block_progress_bar PRIVATE indicators::indicators)
 
 add_executable(dynamic_progress dynamic_progress.cpp)
 target_link_libraries(dynamic_progress PRIVATE indicators::indicators)
+
+add_executable(max_progress max_progress.cpp)
+target_link_libraries(max_progress PRIVATE indicators::indicators)
+

--- a/samples/max_progress.cpp
+++ b/samples/max_progress.cpp
@@ -1,0 +1,30 @@
+#include <chrono>
+#include <indicators/block_progress_bar.hpp>
+#include <indicators/cursor_control.hpp>
+#include <thread>
+
+int main() {
+
+  // Hide cursor
+  indicators::show_console_cursor(false);
+
+  indicators::BlockProgressBar bar{
+    indicators::option::BarWidth{80},
+    indicators::option::FontStyles{
+          std::vector<indicators::FontStyle>{indicators::FontStyle::bold}},
+    indicators::option::MaxProgress{400}
+  };
+
+  // Update bar state
+  while (true) {
+    bar.tick();
+    if (bar.is_completed())
+      break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  // Show cursor
+  indicators::show_console_cursor(true);
+
+  return 0;
+}


### PR DESCRIPTION
The MaxProgress option allows you to set the maximum number of ticks that are within a progress bar. Each call to `tick()` increments the tick count. The progress bar percentage is the number of ticks divided by the `MaxProgress` option.

Let's say you have a queue of 5,245 items that you're processing. If you set `MaxProgress` to `5245`, then you can just call `tick()` each you're done processing each item to update the progress bar the appropriate amount.