### PR TITLE
Elevate #includes from being nested in the namespace.

### DIFF
--- a/include/indicators/terminal_size.hpp
+++ b/include/indicators/terminal_size.hpp
@@ -2,10 +2,11 @@
 #pragma once
 #include <utility>
 
-namespace indicators {
 
 #if defined(_MSC_VER)
 #include <windows.h>
+
+namespace indicators {
 
 static inline std::pair<size_t, size_t> terminal_size() {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -18,9 +19,14 @@ static inline std::pair<size_t, size_t> terminal_size() {
 
 size_t terminal_width() { return terminal_size().second; }
 
+} // namespace indicators
+
 #else
+
 #include <sys/ioctl.h> //ioctl() and TIOCGWINSZ
 #include <unistd.h>    // for STDOUT_FILENO
+
+namespace indicators {
 
 static inline std::pair<size_t, size_t> terminal_size() {
   struct winsize size;
@@ -29,6 +35,8 @@ static inline std::pair<size_t, size_t> terminal_size() {
 }
 
 static inline size_t terminal_width() { return terminal_size().second; }
-#endif
 
 } // namespace indicators
+
+#endif
+


### PR DESCRIPTION
This _may_ address issue #64. I ran into a similar problem on Linux.

Because the `#include` directives were inside the namespace, the definitions they provided were also nested inside the namespace.