### PR TITLE
Change include guard to win32

### DIFF
--- a/include/indicators/terminal_size.hpp
+++ b/include/indicators/terminal_size.hpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #include <windows.h>
 
 namespace indicators {


### PR DESCRIPTION
Fix for compilation error seen in #64 with mingw

https://github.com/p-ranav/indicators/issues/64