### PR TITLE
Mitigate overflow when calculating ETA

### DIFF
--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -200,9 +200,10 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
-                                                   max_progress / progress_)
-                          : 0);
+            progress_ > 0
+                ? static_cast<long long>(std::ceil(float(elapsed.count()) *
+                                                   max_progress / progress_))
+                : 0);
         auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
         details::write_duration(os, remaining);
       } else {

--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -200,7 +200,9 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(elapsed.count() * max_progress / progress_) : 0);
+            progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
+                                                   max_progress / progress_)
+                          : 0);
         auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
         details::write_duration(os, remaining);
       } else {

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -255,9 +255,10 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(float(elapsed_.count()) *
-                                                   max_progress / progress_)
-                          : 0);
+            progress_ > 0
+                ? static_cast<long long>(std::ceil(float(elapsed_.count()) *
+                                                   max_progress / progress_))
+                : 0);
         auto remaining = eta > elapsed_ ? (eta - elapsed_) : (elapsed_ - eta);
         details::write_duration(os, remaining);
       } else {

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -256,7 +256,7 @@ private:
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
             progress_ > 0 ? static_cast<long long>(elapsed_.count() *
-                                                   max_progress / progress_)
+                                                   (max_progress / progress_))
                           : 0);
         auto remaining = eta > elapsed_ ? (eta - elapsed_) : (elapsed_ - eta);
         details::write_duration(os, remaining);

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -255,8 +255,8 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(elapsed_.count() *
-                                                   (max_progress / progress_))
+            progress_ > 0 ? static_cast<long long>(float(elapsed_.count()) *
+                                                   max_progress / progress_)
                           : 0);
         auto remaining = eta > elapsed_ ? (eta - elapsed_) : (elapsed_ - eta);
         details::write_duration(os, remaining);

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -195,9 +195,10 @@ public:
       else
         os << " [";
       auto eta = std::chrono::nanoseconds(
-          progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
-                                                 max_progress / progress_)
-                        : 0);
+          progress_ > 0
+              ? static_cast<long long>(std::ceil(float(elapsed.count()) *
+                                                 max_progress / progress_))
+              : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
       details::write_duration(os, remaining);
       os << "]";

--- a/include/indicators/progress_spinner.hpp
+++ b/include/indicators/progress_spinner.hpp
@@ -195,7 +195,9 @@ public:
       else
         os << " [";
       auto eta = std::chrono::nanoseconds(
-          progress_ > 0 ? static_cast<long long>(elapsed.count() * max_progress / progress_) : 0);
+          progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
+                                                 max_progress / progress_)
+                        : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
       details::write_duration(os, remaining);
       os << "]";

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -1788,9 +1788,10 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(float(elapsed_.count()) *
-                                                   max_progress / progress_)
-                          : 0);
+            progress_ > 0
+                ? static_cast<long long>(std::ceil(float(elapsed_.count()) *
+                                                   max_progress / progress_))
+                : 0);
         auto remaining = eta > elapsed_ ? (eta - elapsed_) : (elapsed_ - eta);
         details::write_duration(os, remaining);
       } else {
@@ -2089,9 +2090,10 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
-                                                   max_progress / progress_)
-                          : 0);
+            progress_ > 0
+                ? static_cast<long long>(std::ceil(float(elapsed.count()) *
+                                                   max_progress / progress_))
+                : 0);
         auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
         details::write_duration(os, remaining);
       } else {
@@ -2798,9 +2800,10 @@ public:
       else
         os << " [";
       auto eta = std::chrono::nanoseconds(
-          progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
-                                                 max_progress / progress_)
-                        : 0);
+          progress_ > 0
+              ? static_cast<long long>(std::ceil(float(elapsed.count()) *
+                                                 max_progress / progress_))
+              : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
       details::write_duration(os, remaining);
       os << "]";

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -1788,8 +1788,8 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(elapsed_.count() *
-                                                   (max_progress / progress_))
+            progress_ > 0 ? static_cast<long long>(float(elapsed_.count()) *
+                                                   max_progress / progress_)
                           : 0);
         auto remaining = eta > elapsed_ ? (eta - elapsed_) : (elapsed_ - eta);
         details::write_duration(os, remaining);
@@ -2089,8 +2089,8 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(elapsed.count() *
-                                                   (max_progress / progress_))
+            progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
+                                                   max_progress / progress_)
                           : 0);
         auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
         details::write_duration(os, remaining);
@@ -2798,8 +2798,8 @@ public:
       else
         os << " [";
       auto eta = std::chrono::nanoseconds(
-          progress_ > 0 ? static_cast<long long>(elapsed.count() *
-                                                 (max_progress / progress_))
+          progress_ > 0 ? static_cast<long long>(float(elapsed.count()) *
+                                                 max_progress / progress_)
                         : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
       details::write_duration(os, remaining);

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -1789,7 +1789,7 @@ private:
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
             progress_ > 0 ? static_cast<long long>(elapsed_.count() *
-                                                   max_progress / progress_)
+                                                   (max_progress / progress_))
                           : 0);
         auto remaining = eta > elapsed_ ? (eta - elapsed_) : (elapsed_ - eta);
         details::write_duration(os, remaining);
@@ -2089,7 +2089,9 @@ private:
 
       if (saved_start_time) {
         auto eta = std::chrono::nanoseconds(
-            progress_ > 0 ? static_cast<long long>(elapsed.count() * max_progress / progress_) : 0);
+            progress_ > 0 ? static_cast<long long>(elapsed.count() *
+                                                   (max_progress / progress_))
+                          : 0);
         auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
         details::write_duration(os, remaining);
       } else {
@@ -2796,7 +2798,9 @@ public:
       else
         os << " [";
       auto eta = std::chrono::nanoseconds(
-          progress_ > 0 ? static_cast<long long>(elapsed.count() * max_progress / progress_) : 0);
+          progress_ > 0 ? static_cast<long long>(elapsed.count() *
+                                                 (max_progress / progress_))
+                        : 0);
       auto remaining = eta > elapsed ? (eta - elapsed) : (elapsed - eta);
       details::write_duration(os, remaining);
       os << "]";


### PR DESCRIPTION
Mitigates the overflow that occurs when max progress is very large.

See #77 