### PR TITLE
Uninitialized local variable in terminal_size

### DIFF
--- a/include/indicators/terminal_size.hpp
+++ b/include/indicators/terminal_size.hpp
@@ -29,7 +29,7 @@ static inline size_t terminal_width() { return terminal_size().second; }
 namespace indicators {
 
 static inline std::pair<size_t, size_t> terminal_size() {
-  struct winsize size;
+  struct winsize size{};
   ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
   return {static_cast<size_t>(size.ws_row), static_cast<size_t>(size.ws_col)};
 }

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -687,7 +687,7 @@ static inline size_t terminal_width() { return terminal_size().second; }
 namespace indicators {
 
 static inline std::pair<size_t, size_t> terminal_size() {
-  struct winsize size;
+  struct winsize size{};
   ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
   return {static_cast<size_t>(size.ws_row), static_cast<size_t>(size.ws_col)};
 }


### PR DESCRIPTION
On MacOS `ioctl` doesn't fill size structure for non-tty `fd`.
In such case `terminal_size` returns random value from stack.

P.S. I found this when I used `ProgressBar` with `option::Completed{terminal_width() == 0}` to add newlines when stdout is piped.