### PR TITLE
Replaced mbstowcs with mbstowcs_s

### DIFF
--- a/include/indicators/display_width.hpp
+++ b/include/indicators/display_width.hpp
@@ -309,18 +309,33 @@ static inline int mk_wcswidth_cjk(const wchar_t *pwcs, size_t n) {
 }
 
 // convert UTF-8 string to wstring
-static inline std::wstring utf8_decode(const std::string &s) {
-  std::string curLocale = setlocale(LC_ALL, "");
-  const char *_Source = s.c_str();
-  size_t _Dsize = strlen(_Source) + 1;
-  wchar_t *_Dest = new wchar_t[_Dsize];
-  size_t _Osize;
-  mbstowcs_s(&_Osize, _Dest, _Dsize, _Source, _Dsize);
-  std::wstring result = _Dest;
-  delete[] _Dest;
-  setlocale(LC_ALL, curLocale.c_str());
-  return result;
+#ifdef _MSC_VER
+static inline std::wstring utf8_decode(const std::string& s) {
+    std::string curLocale = setlocale(LC_ALL, "");
+    const char* _Source = s.c_str();
+    size_t _Dsize = std::strlen(_Source) + 1;
+    wchar_t* _Dest = new wchar_t[_Dsize];
+    size_t _Osize;
+    mbstowcs_s(&_Osize, _Dest, _Dsize, _Source, _Dsize);
+    std::wstring result = _Dest;
+    delete[] _Dest;
+    setlocale(LC_ALL, curLocale.c_str());
+    return result;
 }
+#else 
+static inline std::wstring utf8_decode(const std::string& s) {
+    std::string curLocale = setlocale(LC_ALL, "");
+    const char* _Source = s.c_str();
+    size_t _Dsize = mbstowcs(NULL, _Source, 0) + 1;
+    wchar_t* _Dest = new wchar_t[_Dsize];
+    wmemset(_Dest, 0, _Dsize);
+    mbstowcs(_Dest, _Source, _Dsize);
+    std::wstring result = _Dest;
+    delete[] _Dest;
+    setlocale(LC_ALL, curLocale.c_str());
+    return result;
+}
+#endif
 
 } // namespace details
 

--- a/include/indicators/display_width.hpp
+++ b/include/indicators/display_width.hpp
@@ -312,10 +312,10 @@ static inline int mk_wcswidth_cjk(const wchar_t *pwcs, size_t n) {
 static inline std::wstring utf8_decode(const std::string &s) {
   std::string curLocale = setlocale(LC_ALL, "");
   const char *_Source = s.c_str();
-  size_t _Dsize = mbstowcs(NULL, _Source, 0) + 1;
+  size_t _Dsize = strlen(_Source) + 1;
   wchar_t *_Dest = new wchar_t[_Dsize];
-  wmemset(_Dest, 0, _Dsize);
-  mbstowcs(_Dest, _Source, _Dsize);
+  size_t _Osize;
+  mbstowcs_s(&_Osize, _Dest, _Dsize, _Source, _Dsize);
   std::wstring result = _Dest;
   delete[] _Dest;
   setlocale(LC_ALL, curLocale.c_str());


### PR DESCRIPTION
This fixes the MSVC compiler deprecation warning for mbstowcs in CXX20.

Related to #117