### PR TITLE
Bug fix: check prefix and postfix length errors

### DIFF
--- a/include/indicators/block_progress_bar.hpp
+++ b/include/indicators/block_progress_bar.hpp
@@ -164,7 +164,7 @@ private:
     }
   }
 
-  std::pair<std::string, size_t> get_prefix_text() {
+  std::pair<std::string, int> get_prefix_text() {
     std::stringstream os;
     os << get_value<details::ProgressBarOption::prefix_text>();
     const auto result = os.str();
@@ -172,7 +172,7 @@ private:
     return {result, result_size};
   }
 
-  std::pair<std::string, size_t> get_postfix_text() {
+  std::pair<std::string, int> get_postfix_text() {
     std::stringstream os;
     const auto max_progress = get_value<details::ProgressBarOption::max_progress>();
     auto now = std::chrono::high_resolution_clock::now();
@@ -269,7 +269,9 @@ public:
     const auto terminal_width = terminal_size().second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
-    if (remaining > 0) {
+    if (prefix_length == -1 || postfix_length == -1) {
+      os << "\r";
+    } else if (remaining > 0) {
       os << std::string(remaining, ' ') << "\r";
     } else if (remaining < 0) {
       // Do nothing. Maybe in the future truncate postfix with ...

--- a/include/indicators/indeterminate_progress_bar.hpp
+++ b/include/indicators/indeterminate_progress_bar.hpp
@@ -160,7 +160,7 @@ private:
   template <typename Indicator> friend class DynamicProgress;
   std::atomic<bool> multi_progress_mode_{false};
 
-  std::pair<std::string, size_t> get_prefix_text() {
+  std::pair<std::string, int> get_prefix_text() {
     std::stringstream os;
     os << get_value<details::ProgressBarOption::prefix_text>();
     const auto result = os.str();
@@ -168,7 +168,7 @@ private:
     return {result, result_size};
   }
 
-  std::pair<std::string, size_t> get_postfix_text() {
+  std::pair<std::string, int> get_postfix_text() {
     std::stringstream os;
     os << " " << get_value<details::ProgressBarOption::postfix_text>();
 
@@ -219,7 +219,9 @@ public:
     const auto terminal_width = terminal_size().second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
-    if (remaining > 0) {
+    if (prefix_length == -1 || postfix_length == -1) {
+      os << "\r";
+    } else if (remaining > 0) {
       os << std::string(remaining, ' ') << "\r";
     } else if (remaining < 0) {
       // Do nothing. Maybe in the future truncate postfix with ...

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -216,7 +216,7 @@ private:
     }
   }
 
-  std::pair<std::string, size_t> get_prefix_text() {
+  std::pair<std::string, int> get_prefix_text() {
     std::stringstream os;
     os << get_value<details::ProgressBarOption::prefix_text>();
     const auto result = os.str();
@@ -224,7 +224,7 @@ private:
     return {result, result_size};
   }
 
-  std::pair<std::string, size_t> get_postfix_text() {
+  std::pair<std::string, int> get_postfix_text() {
     std::stringstream os;
     const auto max_progress =
         get_value<details::ProgressBarOption::max_progress>();
@@ -338,7 +338,9 @@ public:
     const auto terminal_width = terminal_size().second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
-    if (remaining > 0) {
+    if (prefix_length == -1 || postfix_length == -1) {
+      os << "\r";
+    } else if (remaining > 0) {
       os << std::string(remaining, ' ') << "\r";
     } else if (remaining < 0) {
       // Do nothing. Maybe in the future truncate postfix with ...

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -2128,7 +2128,7 @@ private:
     }
   }
 
-  std::pair<std::string, size_t> get_prefix_text() {
+  std::pair<std::string, int> get_prefix_text() {
     std::stringstream os;
     os << get_value<details::ProgressBarOption::prefix_text>();
     const auto result = os.str();
@@ -2136,7 +2136,7 @@ private:
     return {result, result_size};
   }
 
-  std::pair<std::string, size_t> get_postfix_text() {
+  std::pair<std::string, int> get_postfix_text() {
     std::stringstream os;
     const auto max_progress =
         get_value<details::ProgressBarOption::max_progress>();
@@ -2250,7 +2250,9 @@ public:
     const auto terminal_width = terminal_size().second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
-    if (remaining > 0) {
+    if (prefix_length == -1 || postfix_length == -1) {
+      os << "\r";
+    } else if (remaining > 0) {
       os << std::string(remaining, ' ') << "\r";
     } else if (remaining < 0) {
       // Do nothing. Maybe in the future truncate postfix with ...
@@ -2437,7 +2439,7 @@ private:
     }
   }
 
-  std::pair<std::string, size_t> get_prefix_text() {
+  std::pair<std::string, int> get_prefix_text() {
     std::stringstream os;
     os << get_value<details::ProgressBarOption::prefix_text>();
     const auto result = os.str();
@@ -2445,7 +2447,7 @@ private:
     return {result, result_size};
   }
 
-  std::pair<std::string, size_t> get_postfix_text() {
+  std::pair<std::string, int> get_postfix_text() {
     std::stringstream os;
     const auto max_progress = get_value<details::ProgressBarOption::max_progress>();
     auto now = std::chrono::high_resolution_clock::now();
@@ -2542,7 +2544,9 @@ public:
     const auto terminal_width = terminal_size().second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
-    if (remaining > 0) {
+    if (prefix_length == -1 || postfix_length == -1) {
+      os << "\r";
+    } else if (remaining > 0) {
       os << std::string(remaining, ' ') << "\r";
     } else if (remaining < 0) {
       // Do nothing. Maybe in the future truncate postfix with ...
@@ -2724,7 +2728,7 @@ private:
   template <typename Indicator> friend class DynamicProgress;
   std::atomic<bool> multi_progress_mode_{false};
 
-  std::pair<std::string, size_t> get_prefix_text() {
+  std::pair<std::string, int> get_prefix_text() {
     std::stringstream os;
     os << get_value<details::ProgressBarOption::prefix_text>();
     const auto result = os.str();
@@ -2732,7 +2736,7 @@ private:
     return {result, result_size};
   }
 
-  std::pair<std::string, size_t> get_postfix_text() {
+  std::pair<std::string, int> get_postfix_text() {
     std::stringstream os;
     os << " " << get_value<details::ProgressBarOption::postfix_text>();
 
@@ -2783,7 +2787,9 @@ public:
     const auto terminal_width = terminal_size().second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
-    if (remaining > 0) {
+    if (prefix_length == -1 || postfix_length == -1) {
+      os << "\r";
+    } else if (remaining > 0) {
       os << std::string(remaining, ' ') << "\r";
     } else if (remaining < 0) {
       // Do nothing. Maybe in the future truncate postfix with ...


### PR DESCRIPTION
This is a bug fix…

if prefix or postfix contains characters like tabs ('\t') then `mk_wcwidth()` and `display_width()` return -1.
This -1 gets converted to a `size_t` type which is unsigned and makes the value very large.
This large value is then used in:

`const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);`

and it will calculate wrong lengths and in my case overflow the terminal line.