### PR TITLE
Add missing <cstdint> header

### DIFF
--- a/include/indicators/termcolor.hpp
+++ b/include/indicators/termcolor.hpp
@@ -14,6 +14,7 @@
 
 #include <iostream>
 #include <cstdio>
+#include <cstdint>
 
 // Detect target's platform and set some macros in order to wrap platform
 // specific code this library depends on.

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -46,6 +46,7 @@ enum class ProgressType { incremental, decremental };
 
 #include <iostream>
 #include <cstdio>
+#include <cstdint>
 
 // Detect target's platform and set some macros in order to wrap platform
 // specific code this library depends on.


### PR DESCRIPTION
Fixes the `‘uint8_t’ has not been declared` error with gcc 13.1.1.

BTW, do I actually need to duplicate the change in `single_include/indicators/indicators.hpp`? It seems we can automatically amalgamate it in CI or don't commit the file at all.