### PR TITLE
Query /dev/tty for the terminal size

### DIFF
--- a/include/indicators/terminal_size.hpp
+++ b/include/indicators/terminal_size.hpp
@@ -24,14 +24,19 @@ static inline size_t terminal_width() { return terminal_size().second; }
 
 #else
 
-#include <sys/ioctl.h> //ioctl() and TIOCGWINSZ
-#include <unistd.h>    // for STDOUT_FILENO
+#include <fcntl.h>     // open and O_RDWR
+#include <sys/ioctl.h> // ioctl() and TIOCGWINSZ
+#include <unistd.h>    // close
 
 namespace indicators {
 
 static inline std::pair<size_t, size_t> terminal_size() {
   struct winsize size{};
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
+  int fd = open("/dev/tty", O_RDWR);
+  if (fd >= 0) {
+    ioctl(fd, TIOCGWINSZ, &size);
+    close(fd);
+  }
   return {static_cast<size_t>(size.ws_row), static_cast<size_t>(size.ws_col)};
 }
 

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -975,14 +975,19 @@ static inline size_t terminal_width() { return terminal_size().second; }
 
 #else
 
-#include <sys/ioctl.h> //ioctl() and TIOCGWINSZ
-#include <unistd.h>    // for STDOUT_FILENO
+#include <fcntl.h>     // open and O_RDWR
+#include <sys/ioctl.h> // ioctl() and TIOCGWINSZ
+#include <unistd.h>    // close
 
 namespace indicators {
 
 static inline std::pair<size_t, size_t> terminal_size() {
   struct winsize size{};
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
+  int fd = open("/dev/tty", O_RDWR);
+  if (fd >= 0) {
+    ioctl(fd, TIOCGWINSZ, &size);
+    close(fd);
+  }
   return {static_cast<size_t>(size.ws_row), static_cast<size_t>(size.ws_col)};
 }
 


### PR DESCRIPTION
The device file `/dev/tty` is available even if `stdout` is closed or redirected, in which case the width would have been reported as 0 rather than the size of the terminal that we're running in.

Tested on both macOS and Linux and behaves as expected.