### PR TITLE
Fix Localization Information Restoration Issue: Change setlocale(LC_ALL, "") to setlocale(LC_ALL, NULL)

### DIFF
--- a/include/indicators/display_width.hpp
+++ b/include/indicators/display_width.hpp
@@ -311,7 +311,7 @@ static inline int mk_wcswidth_cjk(const wchar_t *pwcs, size_t n) {
 // convert UTF-8 string to wstring
 #ifdef _MSC_VER
 static inline std::wstring utf8_decode(const std::string& s) {
-    auto r = setlocale(LC_ALL, "");
+    auto r = setlocale(LC_ALL, NULL);
     std::string curLocale;
     if (r)
       curLocale = r;
@@ -327,7 +327,7 @@ static inline std::wstring utf8_decode(const std::string& s) {
 }
 #else 
 static inline std::wstring utf8_decode(const std::string& s) {
-    auto r = setlocale(LC_ALL, "");
+    auto r = setlocale(LC_ALL, NULL);
     std::string curLocale;
     if (r)
       curLocale = r;


### PR DESCRIPTION
Fix the issue where the localization information is set before the program calls the `utf8_decode` function in the project code. After calling the `utf8_decode`function, the restored localization information is the default setting from the user environment variables, rather than the current program's localization information. Therefore, the `setlocale(LC_ALL, "")` call should be changed to `setlocale(LC_ALL, NULL)` to align with the code logic.