### PR TITLE
Fix lsb error for ticks with huge max_progress values.

### DIFF
--- a/samples/block_progress_bar.cpp
+++ b/samples/block_progress_bar.cpp
@@ -17,7 +17,7 @@ int main() {
   auto progress = 0.0f;
   while (true) {
     bar.set_progress(progress);
-    progress += 0.25f;
+    progress += 1;
     if (bar.is_completed())
       break;
     std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/samples/block_progress_bar.cpp
+++ b/samples/block_progress_bar.cpp
@@ -14,10 +14,10 @@ int main() {
           std::vector<indicators::FontStyle>{indicators::FontStyle::bold}}};
 
   // Update bar state
-  auto progress = 0.0f;
+  size_t progress = 0;
   while (true) {
     bar.set_progress(progress);
-    progress += 1;
+    progress++;
     if (bar.is_completed())
       break;
     std::this_thread::sleep_for(std::chrono::milliseconds(50));


### PR DESCRIPTION
When the `max_progress` value is >1.67772e+07, the `progress_` which is `float`, is not changed when `tick()` is called as +1 is outside of the precission for a float value. The bar stays at value of 1.67772e+07 and 67%, like in the example below:
![image](https://github.com/user-attachments/assets/d313cfbe-4578-4c6f-9df7-b45a58e97747)

In this fix I introduced `tics_` varialbe of `size_t` which is increased with every tick. And the `progress_` is calculated as a ratio of `tick_/max_progress`.
The breaking and required change is the change of `set_progress(float)` to `set_progress(size_t)`, so it modifies directly the `tics_` value.