### PR TITLE
Increase cmake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 
 if(DEFINED PROJECT_NAME)
   set(INDICATORS_SUBPROJECT ON)


### PR DESCRIPTION
Current cmake gives following deprecation warning:

```
CMake Deprecation Warning at build/default/_deps/indicators-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```