### PR TITLE
Add better support for outputting to stderr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
   project(indicators VERSION 2.3.0 LANGUAGES CXX
     HOMEPAGE_URL "https://github.com/p-ranav/indicators"
     DESCRIPTION "Activity Indicators for Modern C++")
+  cmake_minimum_required(VERSION 3.12)
 elseif(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
   project(indicators VERSION 2.3.0 LANGUAGES CXX
     DESCRIPTION "Activity Indicators for Modern C++")

--- a/include/indicators/cursor_control.hpp
+++ b/include/indicators/cursor_control.hpp
@@ -18,7 +18,7 @@ namespace indicators {
 #if defined(_MSC_VER)
 
 static inline void show_console_cursor(bool const show, TerminalHandle hndl = TerminalHandle::StdOut) {
-  HANDLE out = os_handle(hndl);
+  HANDLE out = GetStdHandle(os_handle(hndl));
 
   CONSOLE_CURSOR_INFO cursorInfo;
 
@@ -28,7 +28,7 @@ static inline void show_console_cursor(bool const show, TerminalHandle hndl = Te
 }
 
 static inline void erase_line(TerminalHandle hndl = TerminalHandle::StdOut) {
-  auto hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+  auto hStdout = GetStdHandle(os_handle(hndl));
   if (!hStdout)
     return;
 

--- a/include/indicators/cursor_control.hpp
+++ b/include/indicators/cursor_control.hpp
@@ -1,4 +1,3 @@
-
 #ifndef INDICATORS_CURSOR_CONTROL
 #define INDICATORS_CURSOR_CONTROL
 
@@ -12,12 +11,14 @@
 #include <cstdio>
 #endif
 
+#include "terminal_size.hpp"
+
 namespace indicators {
 
 #if defined(_MSC_VER)
 
-static inline void show_console_cursor(bool const show) {
-  HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+static inline void show_console_cursor(bool const show, TerminalHandle hndl = TerminalHandle::StdOut) {
+  HANDLE out = os_handle(hndl);
 
   CONSOLE_CURSOR_INFO cursorInfo;
 
@@ -26,7 +27,7 @@ static inline void show_console_cursor(bool const show) {
   SetConsoleCursorInfo(out, &cursorInfo);
 }
 
-static inline void erase_line() {
+static inline void erase_line(TerminalHandle hndl = TerminalHandle::StdOut) {
   auto hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
   if (!hStdout)
     return;
@@ -51,12 +52,21 @@ static inline void erase_line() {
 
 #else
 
-static inline void show_console_cursor(bool const show) {
-  std::fputs(show ? "\033[?25h" : "\033[?25l", stdout);
+static inline FILE* os_stream(TerminalHandle hndl)
+{
+  switch (hndl) {
+    case TerminalHandle::StdOut: return stdout;
+    case TerminalHandle::StdErr: return stderr;
+  }
+  return stdout;
 }
 
-static inline void erase_line() {
-  std::fputs("\r\033[K", stdout);
+static inline void show_console_cursor(bool const show, TerminalHandle hndl = TerminalHandle::StdOut) {
+  std::fputs(show ? "\033[?25h" : "\033[?25l", os_stream(hndl));
+}
+
+static inline void erase_line(TerminalHandle hndl = TerminalHandle::StdOut) {
+  std::fputs("\r\033[K", os_stream(hndl));
 }
 
 #endif

--- a/include/indicators/display_width.hpp
+++ b/include/indicators/display_width.hpp
@@ -74,8 +74,8 @@ namespace details {
  */
 
 struct interval {
-  int first;
-  int last;
+  wchar_t first;
+  wchar_t last;
 };
 
 /* auxiliary function for binary search in interval table */

--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -84,7 +84,7 @@ public:
                 option::ProgressType{ProgressType::incremental},
                 std::forward<Args>(args)...),
             details::get<details::ProgressBarOption::stream>(
-                option::Stream{std::cout}, std::forward<Args>(args)...)) {
+                                                             option::Stream{TerminalHandle::StdOut}, std::forward<Args>(args)...)) {
 
     // if progress is incremental, start from min_progress
     // else start from max_progress
@@ -278,12 +278,18 @@ private:
     const auto result_size = unicode::display_width(result);
     return {result, result_size};
   }
+private:
+  std::ostream& as_stream(TerminalHandle hndl) {
+    if (hndl == TerminalHandle::StdOut) { return std::cout; }
+    return std::cerr;
+  }
 
 public:
   void print_progress(bool from_multi_progress = false) {
     std::lock_guard<std::mutex> lock{mutex_};
 
-    auto &os = get_value<details::ProgressBarOption::stream>();
+    auto stream_type = get_value<details::ProgressBarOption::stream>();
+    auto &os = as_stream(stream_type);
 
     const auto type = get_value<details::ProgressBarOption::progress_type>();
     const auto min_progress =
@@ -335,7 +341,7 @@ public:
     const auto start_length = get_value<details::ProgressBarOption::start>().size();
     const auto bar_width = get_value<details::ProgressBarOption::bar_width>();
     const auto end_length = get_value<details::ProgressBarOption::end>().size();
-    const auto terminal_width = terminal_size().second;
+    const auto terminal_width = terminal_size(stream_type).second;
     // prefix + bar_width + postfix should be <= terminal_width
     const int remaining = terminal_width - (prefix_length + start_length + bar_width + end_length + postfix_length);
     if (prefix_length == -1 || postfix_length == -1) {

--- a/include/indicators/setting.hpp
+++ b/include/indicators/setting.hpp
@@ -32,6 +32,7 @@ SOFTWARE.
 #include <indicators/color.hpp>
 #include <indicators/font_style.hpp>
 #include <indicators/progress_type.hpp>
+#include <indicators/terminal_size.hpp>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -215,7 +216,8 @@ using FontStyles =
 using MinProgress = details::IntegerSetting<details::ProgressBarOption::min_progress>;
 using MaxProgress = details::IntegerSetting<details::ProgressBarOption::max_progress>;
 using ProgressType = details::Setting<ProgressType, details::ProgressBarOption::progress_type>;
-using Stream = details::Setting<std::ostream &, details::ProgressBarOption::stream>;
+
+using Stream = details::Setting<TerminalHandle, details::ProgressBarOption::stream>;
 } // namespace option
 } // namespace indicators
 

--- a/include/indicators/terminal_size.hpp
+++ b/include/indicators/terminal_size.hpp
@@ -1,24 +1,37 @@
-
 #ifndef INDICATORS_TERMINAL_SIZE
 #define INDICATORS_TERMINAL_SIZE
 #include <utility>
 
+namespace indicators {
+  enum class TerminalHandle {
+    StdOut, StdErr
+  };
+};
 
 #if defined(_WIN32)
 #include <windows.h>
 
 namespace indicators {
 
-static inline std::pair<size_t, size_t> terminal_size() {
+static inline DWORD os_handle(TerminalHandle hndl)
+{
+  switch (hndl) {
+    case TerminalHandle::StdOut: return STD_OUTPUT_HANDLE;
+    case TerminalHandle::StdErr: return STD_ERROR_HANDLE;
+  }
+  return STD_OUTPUT_HANDLE;
+}
+
+static inline std::pair<size_t, size_t> terminal_size(TerminalHandle hndl) {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   int cols, rows;
-  GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+  GetConsoleScreenBufferInfo(GetStdHandle(os_handle(hndl)), &csbi);
   cols = csbi.srWindow.Right - csbi.srWindow.Left + 1;
   rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
   return {static_cast<size_t>(rows), static_cast<size_t>(cols)};
 }
 
-static inline size_t terminal_width() { return terminal_size().second; }
+static inline size_t terminal_width(TerminalHandle hndl) { return terminal_size(hndl).second; }
 
 } // namespace indicators
 
@@ -29,13 +42,23 @@ static inline size_t terminal_width() { return terminal_size().second; }
 
 namespace indicators {
 
-static inline std::pair<size_t, size_t> terminal_size() {
+static inline int os_handle(TerminalHandle hndl)
+{
+  switch (hndl) {
+    case TerminalHandle::StdOut: return STDOUT_FILENO;
+    case TerminalHandle::StdErr: return STDERR_FILENO;
+  }
+  return STDOUT_FILENO;
+}
+
+
+static inline std::pair<size_t, size_t> terminal_size(TerminalHandle hndl) {
   struct winsize size{};
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
+  ioctl(os_handle(hndl), TIOCGWINSZ, &size);
   return {static_cast<size_t>(size.ws_row), static_cast<size_t>(size.ws_col)};
 }
 
-static inline size_t terminal_width() { return terminal_size().second; }
+static inline size_t terminal_width(TerminalHandle hndl) { return terminal_size(hndl).second; }
 
 } // namespace indicators
 

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -1415,8 +1415,8 @@ namespace details {
  */
 
 struct interval {
-  int first;
-  int last;
+  wchar_t first;
+  wchar_t last;
 };
 
 /* auxiliary function for binary search in interval table */


### PR DESCRIPTION
I am writing an application that outputs data to stdout and user messages (like the current progress) to stderr.  As such i would like to print a progress bar to stderr.

Sadly this is currently not possible with the current master version. While you can set a custom stream in the settings, all the terminal interaction more or less assumes that the stream is stdout; or just ignores the setting completely (see show_console_cursor/erase_line).

This PR tries to fix that situation by letting the user pick explicitly between stdout/stderr.

I also set the cmake minimum to 3.12 to silence some warnings; let me know if you would like me to remove that.