### PR TITLE
Bump CMake version and fix warning on arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT DEFINED PROJECT_NAME)
   set(INDICATORS_IS_TOP_LEVEL ON)
@@ -6,16 +6,9 @@ else()
   set(INDICATORS_IS_TOP_LEVEL OFF)
 endif()
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
-  project(indicators VERSION 2.3.0 LANGUAGES CXX
-    HOMEPAGE_URL "https://github.com/p-ranav/indicators"
-    DESCRIPTION "Activity Indicators for Modern C++")
-elseif(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
-  project(indicators VERSION 2.3.0 LANGUAGES CXX
-    DESCRIPTION "Activity Indicators for Modern C++")
-else()
-  project(indicators VERSION 2.3.0 LANGUAGES CXX)
-endif()
+project(indicators VERSION 2.3.0 LANGUAGES CXX
+  HOMEPAGE_URL "https://github.com/p-ranav/indicators"
+  DESCRIPTION "Activity Indicators for Modern C++")
 
 if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")

--- a/include/indicators/display_width.hpp
+++ b/include/indicators/display_width.hpp
@@ -74,8 +74,8 @@ namespace details {
  */
 
 struct interval {
-  int first;
-  int last;
+  wchar_t first;
+  wchar_t last;
 };
 
 /* auxiliary function for binary search in interval table */

--- a/single_include/indicators/indicators.hpp
+++ b/single_include/indicators/indicators.hpp
@@ -1415,8 +1415,8 @@ namespace details {
  */
 
 struct interval {
-  int first;
-  int last;
+  wchar_t first;
+  wchar_t last;
 };
 
 /* auxiliary function for binary search in interval table */


### PR DESCRIPTION
This pull request updates the build configuration and improves Unicode handling in the codebase. The main changes are an update to the minimum required CMake version and a fix to use the correct type for Unicode interval boundaries.

Build system update:

* Increased the minimum required CMake version to 3.12 and simplified the `project` configuration in `CMakeLists.txt`. 3.8 is ancient.

Fix a compilation warning on ARM64:

* Changed the type of `interval::first` and `interval::last` from `int` to `wchar_t` in both `include/indicators/display_width.hpp` and `single_include/indicators/indicators.hpp`. This fixes the following warning on ARM64:
```log
In file included from .../include/indicators/block_progress_bar.hpp:6:
In file included from .../include/indicators/details/stream_helper.hpp:5:
.../include/indicators/display_width.hpp:86:35: warning: comparison of integers of different signs: 'wchar_t' and 'const int' [-Wsign-compare]
   86 |   if (ucs < table[0].first || ucs > table[max].last)
      |                               ~~~ ^ ~~~~~~~~~~~~~~~
.../include/indicators/display_width.hpp:86:11: warning: comparison of integers of different signs: 'wchar_t' and 'const int' [-Wsign-compare]
   86 |   if (ucs < table[0].first || ucs > table[max].last)
      |       ~~~ ^ ~~~~~~~~~~~~~~
.../include/indicators/display_width.hpp:90:13: warning: comparison of integers of different signs: 'wchar_t' and 'const int' [-Wsign-compare]
   90 |     if (ucs > table[mid].last)
      |         ~~~ ^ ~~~~~~~~~~~~~~~
.../include/indicators/display_width.hpp:92:18: warning: comparison of integers of different signs: 'wchar_t' and 'const int' [-Wsign-compare]
   92 |     else if (ucs < table[mid].first)
      |              ~~~ ^ ~~~~~~~~~~~~~~~~
4 warnings generated.
```
That's because `wchar_t` can be either signed or unsigned, depending on platform and compilation options.