### PR TITLE
Pad percentage 

### DIFF
--- a/include/indicators/progress_bar.hpp
+++ b/include/indicators/progress_bar.hpp
@@ -231,6 +231,7 @@ private:
 
     if (get_value<details::ProgressBarOption::show_percentage>()) {
       os << " "
+         << std::setw(3) // Left pad to 3 characters
          << (std::min)(static_cast<size_t>(static_cast<float>(progress_) /
                                          max_progress * 100),
                      size_t(100))


### PR DESCRIPTION
This avoids misaligned indicators, and things after the percentage moving horizontally when the progress updates. This is especially useful when using lots of bars like the following:

```
  seed   1028[>                             ] 0% [00m:26s] ]
  seed    563[==============================] 100% [00m:29s]
  seed   1090[>                             ] 0% [00m:20s] ]
  seed    625[==============================] 100% [00m:28s]
  seed    656[==============================] 100% [00m:27s]
  seed    687[==============================] 100% [00m:28s]
  seed    718[==============================] 100% [00m:29s]
  seed    997[=================>            ] 58% [00m:16s]
  seed    780[==============================] 100% [00m:30s]
```
Now:
```
  seed   1958[=============================>]  98% [05m:02s]
  seed   1617[==>                           ]   9% [02m:49s]
  seed   2330[==============================] 100% [12m:08s]
  seed   2361[==>                           ]   9% [06m:51s]
  seed   1276[=============>                ]  45% [11m:49s]
  seed   2299[==>                           ]   9% [07m:53s]
```